### PR TITLE
Trial to fix flaky tests

### DIFF
--- a/tests/e2e/helpers/runners.py
+++ b/tests/e2e/helpers/runners.py
@@ -178,7 +178,6 @@ def _run_once(
             cmd,
             logfile=logfile,
             maxread=PEXPECT_BUFFER_SIZE_BYTES,
-            searchwindowsize=PEXPECT_BUFFER_SIZE_BYTES // 100,
             encoding="utf-8",
             timeout=DEFAULT_TIMEOUT_LONG,
         )


### PR DESCRIPTION
1. Try disabling searchwindowsize (will search the entire buffer by default) at feff9ef .