### PR TITLE
Speed up image build

### DIFF
--- a/{{cookiecutter.project_slug}}/.neuro/live.yml
+++ b/{{cookiecutter.project_slug}}/.neuro/live.yml
@@ -37,6 +37,7 @@ images:
     ref: image:$[[ flow.project_id ]]
     dockerfile: $[[ flow.workspace ]]/Dockerfile
     context: $[[ flow.workspace ]]/
+    build_preset: cpu-small
 
 jobs:
 


### PR DESCRIPTION
Use `cpu-small` preset for image builds instead of `cpu-micro` by default